### PR TITLE
Adding HTTP status 500 (internal service error) handling

### DIFF
--- a/soap-client/src/main/java/org/reficio/ws/client/InternalServerException.java
+++ b/soap-client/src/main/java/org/reficio/ws/client/InternalServerException.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2012-2013 Reficio (TM) - Reestablish your software!. All Rights Reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.reficio.ws.client;
+
+/**
+ * Exception thrown when internal server error (500) occurs
+ * @author Szymon.Kolorz
+ */
+
+
+public class InternalServerException extends SoapClientException {
+
+    private String entity;
+
+    public InternalServerException(String message, String entity) {
+        super(message);
+        this.entity = entity;
+    }
+
+    public String getEntity(){
+        return entity;
+    }
+}

--- a/soap-client/src/main/java/org/reficio/ws/client/core/SoapClient.java
+++ b/soap-client/src/main/java/org/reficio/ws/client/core/SoapClient.java
@@ -43,6 +43,7 @@ import org.apache.http.protocol.HttpContext;
 import org.apache.http.util.EntityUtils;
 import org.reficio.ws.SoapException;
 import org.reficio.ws.annotation.ThreadSafe;
+import org.reficio.ws.client.InternalServerException;
 import org.reficio.ws.client.SoapClientException;
 import org.reficio.ws.client.TransmissionException;
 import org.reficio.ws.client.ssl.SSLUtils;
@@ -167,8 +168,12 @@ public final class SoapClient {
             StatusLine statusLine = response.getStatusLine();
             HttpEntity entity = response.getEntity();
             if (statusLine.getStatusCode() >= 300) {
-                EntityUtils.consume(entity);
-                throw new TransmissionException(statusLine.getReasonPhrase(), statusLine.getStatusCode());
+                if (statusLine.getStatusCode() == 500){
+                    throw new InternalServerException(statusLine.getReasonPhrase(), entity == null ? null : EntityUtils.toString(entity));
+                } else {
+                    EntityUtils.consume(entity);
+                    throw new TransmissionException(statusLine.getReasonPhrase(), statusLine.getStatusCode());
+                }
             }
             return entity == null ? null : EntityUtils.toString(entity);
         } catch (SoapException ex) {

--- a/soap-it/src/test/java/org/reficio/ws/it/HttpCooperationTest.java
+++ b/soap-it/src/test/java/org/reficio/ws/it/HttpCooperationTest.java
@@ -21,10 +21,9 @@ package org.reficio.ws.it;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.reficio.ws.client.TransmissionException;
+import org.reficio.ws.client.InternalServerException;
 import org.reficio.ws.server.core.SoapServer;
 
-import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 
 /**
@@ -123,14 +122,13 @@ public class HttpCooperationTest extends AbstractCooperationTest {
 
     @Test
     public void testService15_noSoapAction() throws Exception {
-        TransmissionException expected = null;
+        InternalServerException expected = null;
         try {
             verifyServiceBehavior(15, SKIP_SOAP_ACTION);
-        } catch (TransmissionException ex) {
+        } catch (InternalServerException ex) {
             expected = ex;
         }
         assertNotNull(expected);
-        assertEquals(Integer.valueOf(500), expected.getErrorCode());
     }
 
     @Test
@@ -170,14 +168,13 @@ public class HttpCooperationTest extends AbstractCooperationTest {
 
     @Test
     public void testService23() throws Exception {
-        TransmissionException expected = null;
+        InternalServerException expected = null;
         try {
             verifyServiceBehavior(23);
-        } catch (TransmissionException ex) {
+        } catch (InternalServerException ex) {
             expected = ex;
         }
         assertNotNull(expected);
-        assertEquals(Integer.valueOf(500), expected.getErrorCode());
     }
 
     @Test

--- a/soap-it/src/test/java/org/reficio/ws/it/HttpStatus500Test.java
+++ b/soap-it/src/test/java/org/reficio/ws/it/HttpStatus500Test.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2012-2013 Reficio (TM) - Reestablish your software!. All Rights Reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.reficio.ws.it;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.reficio.ws.SoapException;
+import org.reficio.ws.client.InternalServerException;
+import org.reficio.ws.client.core.SoapClient;
+import org.reficio.ws.server.core.SoapServer;
+import org.reficio.ws.server.responder.RequestResponder;
+import org.springframework.ws.soap.SoapMessage;
+
+import javax.xml.transform.Source;
+
+import static junit.framework.Assert.assertNotNull;
+
+/**
+ * Test http status 500 handling
+ *
+ * @author Szymon.Kolorz
+ */
+public class HttpStatus500Test extends AbstractCooperationTest {
+    private static final String CONTEXT_PATH = "/endpoint500";
+    private static final String VALID_REQUEST = "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\"/>";
+
+    @Test
+    public void HttpStatus500Test() {
+        SoapClient client = new ClientBuilderImpl().buildClient(String.format("%s:%s%s", HOST_URL, HOST_PORT, CONTEXT_PATH));
+        InternalServerException expected = null;
+
+        try {
+            client.post(VALID_REQUEST);
+        } catch (InternalServerException e) {
+            expected = e;
+        }
+        assertNotNull(expected);
+        assertNotNull(expected.getEntity());
+    }
+
+    @Before
+    public void initializeServer() {
+        server = SoapServer.builder()
+                .httpPort(HOST_PORT)
+                .build();
+
+        RequestResponder alwaysFailingResponder = new RequestResponder() {
+            @Override
+            public Source respond(SoapMessage request) {
+                throw new SoapException("sorry, this endpoint always fails");
+            }
+        };
+        server.registerRequestResponder(CONTEXT_PATH, alwaysFailingResponder);
+        server.start();
+    }
+
+    @After
+    public void destroyServer() {
+        server.stop();
+    }
+}


### PR DESCRIPTION
In case of SoapFault (HTTP status 500) InternalErrorException is thrown. 
