### PR TITLE
Update SoapClient.java

### DIFF
--- a/soap-client/src/main/java/org/reficio/ws/client/core/SoapClient.java
+++ b/soap-client/src/main/java/org/reficio/ws/client/core/SoapClient.java
@@ -136,7 +136,10 @@ public final class SoapClient {
     private HttpPost generatePost(String soapAction, String requestEnvelope) {
         try {
             HttpPost post = new HttpPost(endpointUri.toString());
-            StringEntity contentEntity = new StringEntity(requestEnvelope);
+            // ----------------------------------------------------------------
+            // This is the changed code to avoid using ISO characterset.
+            StringEntity contentEntity = new StringEntity(requestEnvelope, "UTF-8");
+            // ----------------------------------------------------------------   
             post.setEntity(contentEntity);
             if (requestEnvelope.contains(SOAP_1_1_NAMESPACE)) {
                 soapAction = soapAction != null ? "\"" + soapAction + "\"" : "";


### PR DESCRIPTION
Changed using the default characterset from ISO to UTF-8 to avoid getting UnsupportedEncodingException using some special characters in soap requests.
